### PR TITLE
Increase switch release debounce timing

### DIFF
--- a/app/boards/arm/glove80/glove80.dtsi
+++ b/app/boards/arm/glove80/glove80.dtsi
@@ -35,8 +35,8 @@ RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4)         RC(3,6) RC(4,6) RC(5,6)   RC(5,7
 		label = "KSCAN";
 
 		diode-direction = "col2row";
-		debounce-press-ms = <1>;
-		debounce-release-ms = <10>;
+		debounce-press-ms = <4>;
+		debounce-release-ms = <20>;
 	};
 
 };


### PR DESCRIPTION
There's a lot of variation between keyswitches, try less aggressive debounce timings to avoid rare instances of double-press, especially on Kailh White switches.

Increasing the release debounce should catch these cases while minimally affecting the time to press. I'm also very slightly (3ms) increasing the press debounce period here. This is very unlikely to be affected by switch noise, but a very small increase to the default setting here could be safer in unforeseen circumstances without perceptibly affecting typing.