### PR TITLE
Maintain built compiler image metadata in S3 files

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,6 +20,7 @@ jobs:
       contents: read
     env:
       ECR_REPOSITORY: zmk-builder-lambda
+      VERSIONS_BUCKET: glove80firmwarepipelines-compilerversionsbucket44-zubaquiyjdam
       UPDATE_COMPILER_VERSIONS_FUNCTION: arn:aws:lambda:us-east-1:431227615537:function:Glove80FirmwarePipelineSt-UpdateCompilerVersions2A-CNxPOHb4VSuV
       REVISION_TAG: ${{ github.sha }}
     steps:
@@ -29,11 +30,11 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::431227615537:role/GithubCompilerLambdaBuilder
           aws-region: us-east-1
-      - name: Extract image tag name
+      - name: Extract container name from branch name
         shell: bash
         run: |
           if [ "$GITHUB_REF" = "refs/heads/main" ]; then
-            tag="latest"
+            tag="branch.main"
           elif [ "$GITHUB_HEAD_REF" ]; then
             pr=${GITHUB_REF#refs/pull/}
             pr=${pr%/merge}
@@ -46,7 +47,7 @@ jobs:
           fi
           # Replace / with . in container tag names
           tag="${tag//\//.}"
-          echo "IMAGE_TAG=${tag}" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=${tag}" >> $GITHUB_ENV
         id: extract_name
       - name: Login to Amazon ECR
         id: login-ecr
@@ -63,10 +64,29 @@ jobs:
       - name: Import OCI image into docker-daemon
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: skopeo --insecure-policy copy oci:directLambdaImage docker-daemon:$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        run: skopeo --insecure-policy copy oci:directLambdaImage docker-daemon:$REGISTRY/$ECR_REPOSITORY:$REVISION_TAG
       - name: Push container image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: docker push $REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        run: docker push $REGISTRY/$ECR_REPOSITORY:$REVISION_TAG
+      - name: Create JSON metadata to represent the built container
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        shell: bash
+        run: |
+          digest="$(docker inspect --format='{{index .RepoDigests 0}}' $REGISTRY/$ECR_REPOSITORY:$REVISION_TAG)"
+          digest="${digest##*@}"
+          jq -n '{ name: $name, revision: $revision, branch: $branch, digest: $digest }' \
+            --arg name     "$CONTAINER_NAME" \
+            --arg revision "$REVISION_TAG" \
+            --arg branch   "$GITHUB_REF" \
+            --arg digest   "$digest" \
+            > "/tmp/$CONTAINER_NAME.json"
+      - name: Upload image metadata file to versions bucket
+        run: aws s3 cp "/tmp/$CONTAINER_NAME.json" "s3://$VERSIONS_BUCKET/images/$CONTAINER_NAME.json"
       - name: Notify the build pipeline that the compile containers have updated
-        run: aws lambda invoke --function-name $UPDATE_COMPILER_VERSIONS_FUNCTION /dev/null
+        run: >-
+          aws lambda invoke --function-name $UPDATE_COMPILER_VERSIONS_FUNCTION
+          --invocation-type Event
+          --cli-binary-format raw-in-base64-out
+          /dev/null

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-22.05
       - uses: cachix/cachix-action@v12

--- a/.github/workflows/cleanup-container.yml
+++ b/.github/workflows/cleanup-container.yml
@@ -16,6 +16,7 @@ jobs:
       contents: read
     env:
       ECR_REPOSITORY: zmk-builder-lambda
+      VERSIONS_BUCKET: glove80firmwarepipelines-compilerversionsbucket44-zubaquiyjdam
       UPDATE_COMPILER_VERSIONS_FUNCTION: arn:aws:lambda:us-east-1:431227615537:function:Glove80FirmwarePipelineSt-UpdateCompilerVersions2A-CNxPOHb4VSuV
       PR_NUMBER: ${{ github.event.number }}
     steps:
@@ -25,14 +26,18 @@ jobs:
           tag="pr${PR_NUMBER}.${GITHUB_HEAD_REF}"
           # Replace / with . in container tag names
           tag="${tag//\//.}"
-          echo "IMAGE_TAG=${tag}" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=${tag}" >> $GITHUB_ENV
         id: extract_name
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::431227615537:role/GithubCompilerLambdaBuilder
           aws-region: us-east-1
-      - name: Delete the container image for the PR from ECR
-        run: aws ecr batch-delete-image --repository-name $ECR_REPOSITORY --image-ids imageTag=$IMAGE_TAG
+      - name: Delete the image metadata file from the versions s3 bucket
+        run: aws s3 rm s3://$VERSIONS_BUCKET/images/$CONTAINER_NAME.json
       - name: Notify the build pipeline that the compile containers have updated
-        run: aws lambda invoke --function-name $UPDATE_COMPILER_VERSIONS_FUNCTION /dev/null
+        run: >-
+          aws lambda invoke --function-name $UPDATE_COMPILER_VERSIONS_FUNCTION
+          --invocation-type Event
+          --cli-binary-format raw-in-base64-out
+          /dev/null

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-22.05
       - uses: cachix/cachix-action@v12


### PR DESCRIPTION
Rather than relying on enumerating the ECR repository. This allows the GH action to convey additional information such as the git branch and revision through to the build pipeline.
