### PR TITLE
nix: rename can -> python-can, removed unused canopen

### DIFF
--- a/nix/zmk.nix
+++ b/nix/zmk.nix
@@ -13,21 +13,11 @@
 let
   # from zephyr/scripts/requirements-base.txt
   packageOverrides = pyself: pysuper: {
-    can = pysuper.can.overrideAttrs (_: {
+    python-can = pysuper.python-can.overrideAttrs (_: {
       # horribly flaky test suite full of assertions about timing.
       # >       assert 0.1 <= took < inc(0.3)
       # E       assert 0.31151700019836426 < 0.3
       # E        +  where 0.3 = inc(0.3)
-      doCheck = false;
-      doInstallCheck = false;
-    });
-
-    canopen = pysuper.can.overrideAttrs (_: {
-      # Also has timing sensitive tests
-      #         task = self.network.send_periodic(0x123, [1, 2, 3], 0.01)
-      #         time.sleep(0.1)
-      # >       self.assertTrue(9 <= bus.queue.qsize() <= 11)
-      # E       AssertionError: False is not true
       doCheck = false;
       doInstallCheck = false;
     });
@@ -36,7 +26,7 @@ let
   python = (buildPackages.python3.override { inherit packageOverrides; }).withPackages (ps: with ps; [
     pyelftools
     pyyaml
-    canopen
+    python-can
     packaging
     progress
     anytree


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
